### PR TITLE
Fix typos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Travel
 
-[![CircleCI](https://circleci.com/gh/dgraph-io/travel.svg?style=svg)](https://circleci.com/gh/dgraph-io/trave)
+[![CircleCI](https://circleci.com/gh/dgraph-io/travel.svg?style=svg)](https://circleci.com/gh/dgraph-io/travel)
 
 Copyright 2020 Dgraph
 contact@dgraph.io

--- a/internal/data/data.go
+++ b/internal/data/data.go
@@ -8,7 +8,7 @@ import (
 	"github.com/dgraph-io/travel/internal/platform/graphql"
 )
 
-// DB provides support for storing data inside of DGraph.
+// DB provides support for storing data inside of Dgraph.
 type DB struct {
 	Schema schema
 	Mutate mutate

--- a/internal/data/query.go
+++ b/internal/data/query.go
@@ -155,7 +155,7 @@ func (q *query) Place(ctx context.Context, placeID string) (Place, error) {
 	query := fmt.Sprintf(`
 query {
 	getPlace(id: %q) {
-		id
+		id,
 		address,
 		avg_user_rating,
 		city_name,
@@ -192,7 +192,7 @@ func (q *query) PlaceByName(ctx context.Context, name string) (Place, error) {
 	query := fmt.Sprintf(`
 query {
 	queryPlace(filter: { name: { eq: %q } }) {
-		id
+		id,
 		address,
 		avg_user_rating,
 		city_name,
@@ -223,13 +223,13 @@ query {
 	return result.QueryPlace[0].Place, nil
 }
 
-// Places returns the collection of palces from the database by the city id.
+// Places returns the collection of places from the database by the city id.
 func (q *query) Places(ctx context.Context, cityID string) ([]Place, error) {
 	query := fmt.Sprintf(`
 query {
 	getCity(id: %q) {
 		places {
-			id
+			id,
 			address,
 			avg_user_rating,
 			city_name,


### PR DESCRIPTION
Fix typos in comments, README, and be consistent about commas in
GraphQL queries.