### PR TITLE
Use dgraph/dgraph image in Docker Compose.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,14 +8,29 @@ networks:
 services:
 
   # Database
-  dgraph:
-    container_name: dgraph
+  dgraph-zero:
+    container_name: dgraph-zero
     networks:
       - shared-network
-    image: dgraph/standalone:v20.03.1
+    image: dgraph/dgraph:v20.03.1
+    environment:
+      - DGRAPH_ZERO_MY=dgraph-zero:5080
+    command: dgraph zero
+  dgraph-alpha:
+    container_name: dgraph-alpha
+    networks:
+      - shared-network
+    image: dgraph/dgraph:v20.03.1
     ports:
       - 8080:8080
-    init: true
+    depends_on:
+      - dgraph-zero
+    environment:
+      - DGRAPH_ALPHA_MY=dgraph-alpha:7080
+      - DGRAPH_ALPHA_LRU_MB=1024
+      - DGRAPH_ALPHA_ZERO=dgraph-zero:5080
+      - DGRAPH_ALPHA_WHITELIST=0.0.0.0/0
+    command: dgraph alpha
 
   # This is the core service API.
   travel-api:
@@ -27,7 +42,7 @@ services:
       - 3000:3000 # API
       - 4000:4000 # DEBUG API
     depends_on:
-      - dgraph
+      - dgraph-alpha
     # environment:
       # - GODEBUG=gctrace=1
 
@@ -41,9 +56,9 @@ services:
       - 80:80 # API
       - 4080:4080 # DEBUG API
     depends_on:
-      - dgraph
+      - dgraph-alpha
     environment:
       - UI_API_KEYS_MAPS_KEY=<ENTER_KEY_HERE>
-      - UI_DGRAPH_API_HOST_INSIDE=dgraph:8080
+      - UI_DGRAPH_API_HOST_INSIDE=dgraph-alpha:8080
       # - GODEBUG=gctrace=1
 

--- a/makefile
+++ b/makefile
@@ -27,10 +27,10 @@ travel-ui:
 run: up seed browser
 
 up:
-	docker-compose up --detach
+	docker-compose up --detach --remove-orphans
 
 down:
-	docker-compose down
+	docker-compose down --remove-orphans
 
 browser:
 	python -m webbrowser "http://localhost"


### PR DESCRIPTION
Use the standard dgraph/dgraph image with a separate container for Dgraph Zero
and Dgraph Alpha.

Changes:
* Add --remove-orphans flag to docker-compose commands in Makefile to clean up
previous "dgraph" container.
* Set appropriate config options for both Zero and Alpha. Namely, the whitelist
config option allows the other containers to access Dgraph's /admin endpoint.