### PR TITLE
Add Kubernetes kind setup.

### DIFF
--- a/k8s/kind/deploy-dgraph.yaml
+++ b/k8s/kind/deploy-dgraph.yaml
@@ -1,0 +1,167 @@
+# This creates a Dgraph cluster with 1 Dgraph Zero and 1 Dgraph Alpha.
+
+# This StatefulSet runs Dgraph Zero.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dgraph-zero
+spec:
+  serviceName: "dgraph-zero"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dgraph-zero
+  template:
+    metadata:
+      labels:
+        app: dgraph-zero
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      containers:
+      - name: zero
+        image: dgraph/dgraph:v20.03.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 5080
+          name: grpc-zero
+        - containerPort: 6080
+          name: http-zero
+        volumeMounts:
+        - name: datadir
+          mountPath: /dgraph
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        command:
+          - bash
+          - "-c"
+          - |
+            set -ex
+            dgraph zero
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 6080
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /state
+            port: 6080
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
+          successThreshold: 1
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: datadir
+        persistentVolumeClaim:
+          claimName: datadir
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+      annotations:
+        volume.alpha.kubernetes.io/storage-class: anything
+    spec:
+      accessModes:
+        - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: 5Gi
+---
+# This StatefulSet runs Dgraph Alpha.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dgraph-alpha
+spec:
+  serviceName: "dgraph-alpha"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dgraph-alpha
+  template:
+    metadata:
+      labels:
+        app: dgraph-alpha
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      containers:
+      - name: alpha
+        image: dgraph/dgraph:v20.03.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 7080
+          name: grpc-alpha-int
+        - containerPort: 8080
+          name: http-alpha
+        - containerPort: 9080
+          name: grpc-alpha
+        volumeMounts:
+        - name: datadir
+          mountPath: /dgraph
+        env:
+          # This should be the same namespace as the dgraph-zero
+          # StatefulSet to resolve a Dgraph Zero's DNS name for
+          # Alpha's --zero flag.
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: DGRAPH_ALPHA_LRU_MB
+            value: "1024"
+          - name: DGRAPH_ALPHA_WHITELIST
+            value: "0.0.0.0/0"
+        command:
+          - bash
+          - "-c"
+          - |
+            set -ex
+            dgraph alpha
+        livenessProbe:
+          httpGet:
+            path: /health?live=1
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
+          successThreshold: 1
+      terminationGracePeriodSeconds: 600
+      volumes:
+      - name: datadir
+        persistentVolumeClaim:
+          claimName: datadir
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+      annotations:
+        volume.alpha.kubernetes.io/storage-class: anything
+    spec:
+      accessModes:
+        - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: 5Gi
+

--- a/k8s/kind/deploy-travel-api.yaml
+++ b/k8s/kind/deploy-travel-api.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: travel-api
+spec:
+  selector:
+    matchLabels:
+      app: travel-api
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      name: travel-api
+      labels:
+        app: travel-api
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      containers:
+      - name: travel-api
+        image: travel-api-amd64:1.0
+        # env:
+        # - name: GODEBUG
+        #   value: gctrace=1
+        ports:
+        - name: travel-api
+          containerPort: 3000
+        - name: debug
+          containerPort: 4000
+        resources: {}
+        resources: {}
+status: {}

--- a/k8s/kind/deploy-travel-ui.yaml
+++ b/k8s/kind/deploy-travel-ui.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: travel-ui
+spec:
+  selector:
+    matchLabels:
+      app: travel-ui
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      name: travel-ui
+      labels:
+        app: travel-ui
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      containers:
+      - name: travel-ui
+        image: travel-ui-amd64:1.0
+        env:
+        - name: UI_API_KEYS_MAPS_KEY
+          value: <ENTER_KEY_HERE>
+        - name: UI_DGRAPH_API_HOST_INSIDE
+          value: localhost:8080
+        # - name: GODEBUG
+        #   value: gctrace=1
+        ports:
+        - name: travel-ui
+          containerPort: 80
+        - name: debug
+          containerPort: 4080
+        resources: {}
+status: {}

--- a/k8s/kind/kind-config.yaml
+++ b/k8s/kind/kind-config.yaml
@@ -1,0 +1,19 @@
+
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  # travel-ui
+  - containerPort: 80
+    hostPort: 80
+  - containerPort: 4080
+    hostPort: 4080
+  # travel-api
+  - containerPort: 3000
+    hostPort: 3000
+  - containerPort: 4000
+    hostPort: 4000
+  # dgraph-alpha
+  - containerPort: 8080
+    hostPort: 8080

--- a/k8s/kind/makefile
+++ b/k8s/kind/makefile
@@ -1,0 +1,43 @@
+SHELL := /bin/bash
+
+all:
+	(cd ../.. && make all)
+
+run: up load services seed browser
+
+up:
+	kind create cluster --name dgraph-travel-cluster --config kind-config.yaml
+
+down:
+	kind delete cluster --name dgraph-travel-cluster
+
+seed:
+	(cd ../.. && make seed)
+
+browser:
+	(cd ../.. && make browser)
+
+load:
+	kind load docker-image travel-ui-amd64:1.0 --name dgraph-travel-cluster
+	kind load docker-image travel-api-amd64:1.0 --name dgraph-travel-cluster
+        # kind load docker-image dgraph/dgraph:v20.03.1 --name dgraph-travel-cluster
+
+services:
+	kubectl create -f deploy-dgraph.yaml
+	kubectl create -f deploy-travel-ui.yaml
+	kubectl create -f deploy-travel-api.yaml
+
+get-pods:
+	kubectl get pods
+
+status:
+	kubectl get nodes
+	kubectl get pods
+	kubectl get services travel-api
+
+delete:
+	kubectl delete -f deploy-dgraph.yaml
+	kubectl delete pvc -l app=dgraph
+	kubectl delete -f deploy-travel-ui.yaml
+	kubectl delete -f deploy-travel-api.yaml
+	@echo ======================================================================


### PR DESCRIPTION
This setup is similar to the K8s kind setup in
https://github.com/ardanlabs/service.

Commands:

`make up`       - Starts the kind cluster
`make load`     - Loads travel-ui and travel-api images into kind
`make services` - Applies the k8s yaml to run travel-api, travel-ui, and dgraph
`make seed`     - Runs the travel-data seed command
`make browser`  - Opens the UI in a browser

`make delete`   - Deletes K8s yaml for travel-api, travel-ui, and dgraph
`make down`     - Deletes kind cluster

`make run`      - Runs `up`, `load`, `services`, `seed`, and `browser`

`make get-pods` - Shows Kubernetes pods
`make status`   - Shows Kubernetes nodes and pods

To try it out, put in your Google Maps API Key in deploy-travel-ui.yaml
where it says `<ENTER_KEY_HERE>`, and export your Google Maps API Key:

    export DATA_API_KEYS_MAPS_KEY=<ENTER_KEY_HERE>

then run `make run`.