### PR TITLE
retry more before reporting failure for GraphQL schema update.

### DIFF
--- a/internal/data/schema.go
+++ b/internal/data/schema.go
@@ -115,7 +115,7 @@ func (s *schema) Create(ctx context.Context) error {
 		}
 	}`
 	vars := map[string]interface{}{"schema": gQLSchema}
-	// mostly it works after 2 retries, but once it took 7th trial for success. So, choosing a
+	// mostly it works after 2 retries, but once it took 7 tries to succeed. So, choosing a
 	// higher value to be safe.
 	numRetries := 10
 	for i := 1; i <= numRetries; i++ {


### PR DESCRIPTION
Recently, the way GraphQL schema is stored in Dgraph has changed, which causes `updateGQLSchema` to fail if tried too early.
This PR makes a few retries before accepting the error from the mutation.